### PR TITLE
activate kill-switch when reboot is pending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'berkshelf'
-gem 'chef', '~> 13.6.0'
-gem 'chefspec', '~> 7.1.0'
-gem 'foodcritic', '~> 12.1.0'
+gem 'chef', '~> 14.11.21'
+gem 'chefspec', '~> 7.2.0'
+gem 'foodcritic', '~> 14.1'
 gem 'kitchen-transport-rsync'
 gem 'kitchen-vagrant'
 gem 'rubocop', '~> 0.51.0'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ There is some monkey-patching that needs to happen to have the option of a clean
     <td>Engage kill switch if a file exists at this path</td>
     <td><tt>C:\\.kill_chef</tt> on Windows, <tt>/.kill_chef</tt> on Linux</td>
   </tr>
+  <tr>
+    <td><tt>['kill_switch']['when_reboot_pending']</tt></td>
+    <td>Bool</td>
+    <td>Engage kill switch if there is a pending reboot</td>
+    <td><tt>true</tt></td>
+  </tr>
 </table>
 
 ## Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,4 @@ default['kill_switch']['touch_dir'] = case node['os']
                                         'C:'
                                       end
 default['kill_switch']['touch_file'] = File.join(node['kill_switch']['touch_dir'].to_s, '.kill_chef')
+default['kill_switch']['when_reboot_pending'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@lqx.net'
 license 'MIT'
 description 'Kill switch to prevent Chef runs from occuring'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.1.0'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 %w[ubuntu debian fedora centos redhat oracle scientific amazon freebsd openbsd mac_os_x solaris2 opensuse opensuseleap

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,6 +10,8 @@ if node['kill_switch']['engage']
   reason = "node attribute ['kill_switch']['engage']"
 elsif File.exist?(node['kill_switch']['touch_file'])
   reason = "touch file #{node['kill_switch']['touch_file']}"
+elsif node['kill_switch']['when_reboot_pending'] && reboot_pending?
+  reason = 'reboot pending'
 else
   return
 end


### PR DESCRIPTION
this is handy to prevent recipes from taking action when a reboot is pending.
a good example of this might be that a prior chef run had shut things down
in preparation for that reboot and another chef run would start those things
back up again.