### PR TITLE
look for scheduled reboot instead of pending

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ There is some monkey-patching that needs to happen to have the option of a clean
     <td><tt>C:\\.kill_chef</tt> on Windows, <tt>/.kill_chef</tt> on Linux</td>
   </tr>
   <tr>
-    <td><tt>['kill_switch']['when_reboot_pending']</tt></td>
+    <td><tt>['kill_switch']['when_reboot_scheduled']</tt></td>
     <td>Bool</td>
-    <td>Engage kill switch if there is a pending reboot</td>
+    <td>Engage kill switch if there is a scheduled reboot (only supported on Ubuntu 16+ presently)</td>
     <td><tt>true</tt></td>
   </tr>
 </table>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 default['kill_switch']['engage'] = false
 default['kill_switch']['normal_exit'] = false
 default['kill_switch']['touch_dir'] = case node['os']
@@ -5,4 +7,4 @@ default['kill_switch']['touch_dir'] = case node['os']
                                         'C:'
                                       end
 default['kill_switch']['touch_file'] = File.join(node['kill_switch']['touch_dir'].to_s, '.kill_chef')
-default['kill_switch']['when_reboot_pending'] = true
+default['kill_switch']['when_reboot_scheduled'] = true

--- a/libraries/reboots.rb
+++ b/libraries/reboots.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+def reboot_scheduled?
+  case node['platform']
+  when 'ubuntu'
+    if node['platform_version'].to_i >= 16
+      cmd = Mixlib::ShellOut.new('busctl get-property org.freedesktop.login1 /org/freedesktop/login1 ' \
+                                 'org.freedesktop.login1.Manager ScheduledShutdown')
+      cmd.run_command
+      return cmd.exitstatus == 0 && (cmd.stdout.include?('"poweroff"') || cmd.stdout.include?('"reboot"'))
+    end
+  end
+  false
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@lqx.net'
 license 'MIT'
 description 'Kill switch to prevent Chef runs from occuring'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.0'
+version '1.1.1'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 %w[ubuntu debian fedora centos redhat oracle scientific amazon freebsd openbsd mac_os_x solaris2 opensuse opensuseleap

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,8 +10,8 @@ if node['kill_switch']['engage']
   reason = "node attribute ['kill_switch']['engage']"
 elsif File.exist?(node['kill_switch']['touch_file'])
   reason = "touch file #{node['kill_switch']['touch_file']}"
-elsif node['kill_switch']['when_reboot_pending'] && reboot_pending?
-  reason = 'reboot pending'
+elsif node['kill_switch']['when_reboot_scheduled'] && reboot_scheduled?
+  reason = 'reboot scheduled'
 else
   return
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -67,7 +67,7 @@ describe 'kill-switch::default' do
       chef_run.node.normal['kill_switch']['engage'] = false
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/.kill_chef').and_return(false)
-      allow_any_instance_of(Chef::Recipe).to receive(:reboot_pending?).and_return(true)
+      allow_any_instance_of(Chef::Recipe).to receive(:reboot_scheduled?).and_return(true)
     end
 
     it 'exits noisily' do


### PR DESCRIPTION
I misunderstood what the built-in `reboot_pending?` function does. It looks to determine
if a host needs rebooted after a package update has been installed and does not strictly
mean that a reboot is scheduled via `shutdown`, which is what I really wanted to test for.

dbus systems support fetching whether a reboot is scheduled. I've effectively only whitelisted
this for Ubuntu systems because that's all I really presently care about but should be able
to be extended to other systems easily if the desire is there.